### PR TITLE
Pluggable state sketch

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "immutable": ">=3",
     "query-string": "^6.2.0",
     "ramda": "^0.25.0",
-    "react": ">=15",
+    "react": ">=16.8.0",
     "react-router": "^4.3.1",
     "rxjs": ">=6"
   },

--- a/src/state-context.js
+++ b/src/state-context.js
@@ -1,0 +1,17 @@
+import React, { useContext } from 'react'
+
+const StateContext = React.createContext('cv-state-context')
+
+export function createStateContext(toView) {
+  return function contextView(state) {
+    return (
+      <StateContext.Provider value={state}>
+        {toView(state)}
+      </StateContext.Provider>
+    )
+  }
+}
+
+export function useStateContext() {
+  return useContext(StateContext)
+}


### PR DESCRIPTION
This is to start discussion on a possible "pluggable state" enhancement.

## How it works:

- `state-context.js` exports  a factory, called `createStateContext`, which can be used to wrap the (userland) `toView` function with a [React context](https://reactjs.org/docs/context.html) which tracks the state

- `state-context.js` also exports a hook, called `useStateContext`, which can be used by any descendant component of the view to immediately access the state without passing it down the component chain.

Obviously, this can be expanded to support more than one context, or passing down just a part of the state (but is it worth? we're passing references anyway)
