### PR TITLE
Add side-effects flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Caballo Vivo",
   "main": "./lib-commonjs",
   "module": "./src",
+  "sideEffects": false,
   "scripts": {
     "test": "jest",
     "prepublishOnly": "npm test && npm run build-commonjs",


### PR DESCRIPTION
Added the `sideEffects` flag so webpack knows it doesn't need to import the parts it doesn't need.

Now, for example if you import only `log` then rxjs won't be brought in at all, because webpack knows the other `caballo-vivo` modules can be ignored.