### PR TITLE
Add other build targets

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,11 +1,6 @@
 {
   "presets": [
-    [
-      "env",
-      {
-        "modules": "commonjs"
-      }
-    ],
+    [ "env", { "modules": false } ],
     "stage-3"
   ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -2,5 +2,10 @@
   "presets": [
     [ "env", { "modules": false } ],
     "stage-3"
-  ]
+  ],
+  "env": {
+    "test": {
+      "plugins": ["transform-es2015-modules-commonjs"]
+    }
+  }
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,12 +1,19 @@
 {
-  "presets": [
-    [ "env", { "modules": false } ],
-    "stage-3"
-  ],
   "env": {
     "commonjs": {
       "presets": [
         [ "env", { "modules": "commonjs" } ],
+        "stage-3"
+      ],
+    },
+    "module": {
+      "presets": [
+        [ "env", { "modules": false } ],
+        "stage-3"
+      ],
+    },
+    "es2015": {
+      "presets": [
         "stage-3"
       ],
     },

--- a/.babelrc
+++ b/.babelrc
@@ -4,6 +4,12 @@
     "stage-3"
   ],
   "env": {
+    "commonjs": {
+      "presets": [
+        [ "env", { "modules": "commonjs" } ],
+        "stage-3"
+      ],
+    },
     "test": {
       "plugins": ["transform-es2015-modules-commonjs"]
     }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
-lib-commonjs
-lib-module
+/lib-*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 lib-commonjs
+lib-module

--- a/package-lock.json
+++ b/package-lock.json
@@ -1769,6 +1769,31 @@
         "gud": "^1.0.0"
       }
     },
+    "cross-env": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
+      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.5",
+        "is-windows": "^1.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -4378,6 +4403,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
     "node-fetch": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "jest",
     "prepublishOnly": "npm test && npm run build-commonjs && npm run build-module",
-    "build-commonjs": "babel src -d lib-commonjs --presets env,stage-3 --no-babelrc",
+    "build-commonjs": "cross-env BABEL_ENV=commonjs babel src -d lib-commonjs",
     "build-module": "babel src -d lib-module"
   },
   "repository": {
@@ -37,6 +37,7 @@
     "babel-jest": "^23.6.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-stage-3": "^6.24.1",
+    "cross-env": "^5.2.0",
     "jest": "^23.6.0",
     "jest-immutable-matchers": "^2.0.1",
     "regenerator-runtime": "^0.13.1"

--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "description": "Caballo Vivo",
   "main": "./lib-commonjs",
   "module": "./lib-module",
-  "es2015": "./src",
+  "es2015": "./lib-es2015",
   "sideEffects": false,
   "scripts": {
     "test": "jest",
-    "prepublishOnly": "npm test && npm run build-commonjs && npm run build-module",
+    "prepublishOnly": "npm test && npm run build-commonjs && npm run build-module && npm run build-es2015",
     "build-commonjs": "cross-env BABEL_ENV=commonjs babel src -d lib-commonjs",
-    "build-module": "babel src -d lib-module"
+    "build-module": "cross-env BABEL_ENV=module babel src -d lib-module",
+    "build-es2015": "cross-env BABEL_ENV=es2015 babel src -d lib-es2015"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -3,12 +3,14 @@
   "version": "1.0.1-0",
   "description": "Caballo Vivo",
   "main": "./lib-commonjs",
-  "module": "./src",
+  "module": "./lib-module",
+  "es2015": "./src",
   "sideEffects": false,
   "scripts": {
     "test": "jest",
-    "prepublishOnly": "npm test && npm run build-commonjs",
-    "build-commonjs": "babel src -d lib-commonjs"
+    "prepublishOnly": "npm test && npm run build-commonjs && npm run build-module",
+    "build-commonjs": "babel src -d lib-commonjs --presets env,stage-3 --no-babelrc",
+    "build-module": "babel src -d lib-module"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Now there are three lib directories:
* `/lib-commonjs` - es5 code with commonjs modules
* `/lib-module` - es5 code with esm modules
* `/lib-es2015` - uncompiled code

With entry points that refer to each one.

This closes #31.