### PR TITLE
Unblock history on unsubscribe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zambezi/caballo-vivo",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zambezi/caballo-vivo",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Caballo Vivo",
   "main": "./lib-commonjs",
   "module": "./lib-module",

--- a/src/location.js
+++ b/src/location.js
@@ -132,7 +132,7 @@ function createLocationHandler$(pathToIntent) {
   }
 
   function handlerForManagedPaths(observer) {
-    history.block(blockManagedPaths(observer, pathToIntent))
+    return history.block(blockManagedPaths(observer, pathToIntent))
   }
 }
 


### PR DESCRIPTION
Once one has been unsubscribed from the location handler that blocks history to manage the paths, history should be again unblocked. 
This can be handled automatically RXJS' observable creation factories. 