### PR TITLE
Refactor distinch until changed

### DIFF
--- a/src/distinct-until-changed.js
+++ b/src/distinct-until-changed.js
@@ -1,11 +1,6 @@
 import { distinctUntilChanged as d } from 'rxjs/operators'
 import { equals } from 'ramda'
 
-export default function distinctUntilChanged(source) {
-  return source.pipe(d(diligentEquals))
-}
+const distinctUntilChanged = d(equals)
 
-function diligentEquals(a, b) {
-  if (typeof a.equals === 'function') return a.equals(b)
-  return equals(a, b)
-}
+export default distinctUntilChanged

--- a/test/distinct-until-changed.test.js
+++ b/test/distinct-until-changed.test.js
@@ -1,47 +1,99 @@
 import * as matchers from 'jest-immutable-matchers'
-import { finalize } from 'rxjs/operators'
+import * as R from 'ramda'
+import { Map } from 'immutable';
+import { TestScheduler } from 'rxjs/testing'
 import { distinctUntilChanged } from '../src'
-import { of } from 'rxjs'
-import { Map, fromJS } from 'immutable'
 
 describe('Distinct until changed', () => {
   beforeEach(() => jest.addMatchers(matchers))
 
-  it('Should understand native JS types', done => {
-    const mockCallBack = jest.fn()
+  it('Should understand native JS types', () => {
+    const testScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected)
+    })
 
-    of(1, 2, 2, 3, 2)
-      .pipe(
-        distinctUntilChanged,
-        finalize(() => {
-          const calls = mockCallBack.mock.calls
-          expect(calls).toEqual([[1], [2], [3], [2]])
-          done()
-        })
-      )
-      .subscribe(mockCallBack, fail)
+    testScheduler.run((helpers) => {
+      const { cold, expectObservable } = helpers
+      const e1 = cold(' -1--2--2-3-2-|');
+      const e1subs = '  ^------------!'
+      const expected = '-1--2----3-2-'
+      expectObservable(e1.pipe(distinctUntilChanged), e1subs).toBe(expected)
+    })
   })
 
-  it('Should understand immutable structures', done => {
-    const mockCallBack = jest.fn()
+  it('Should work with plain javascript objects', () => {
+    const testScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected)
+    })
+    testScheduler.run((helpers) => {
+      const { cold, expectObservable } = helpers
+      const e1 = cold(' -a--b--c---|', {
+        a: { someKey: 'someValue' },
+        b: { someKey: 'someValue' },
+        c: { someKey: 'someValue' }
+      })
+      const e1subs = '  ^----------!'
+      const expected = '-a---------'
+      expectObservable(e1.pipe(distinctUntilChanged), e1subs).toBe(expected, {
+        a: { someKey: 'someValue' }
+      })
+    })
+  })
 
-    of(
-      Map({ a: 1 }),
-      Map({ a: 2 }),
-      Map({ a: 2 }),
-      Map({ a: 3 }),
-      Map({ a: 2 })
-    )
-      .pipe(
-        distinctUntilChanged,
-        finalize(() => {
-          const calls = fromJS(mockCallBack.mock.calls)
-          expect(calls).toEqualImmutable(
-            fromJS([[{ a: 1 }], [{ a: 2 }], [{ a: 3 }], [{ a: 2 }]])
-          )
-          done()
-        })
-      )
-      .subscribe(mockCallBack, fail)
+  
+  it('Should understand immutable structures', () => {
+    const testScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected);
+    })
+
+    testScheduler.run(({cold, expectObservable}) => {
+      const values = [
+        Map({ a: 1 }),
+        Map({ a: 2 }),
+        Map({ a: 2 }),
+        Map({ a: 3 }),
+        Map({ a: 2 })
+      ];
+
+      const e1 = cold('-0-1-2-3-4-|', values);
+
+      expectObservable(e1.pipe(distinctUntilChanged), '^- 20ms -!').toBe('-0-2---3-4-|', values);
+    });
+  })
+
+  it('Should account for implemented equals method', () => {
+    const testScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected)
+    })
+    testScheduler.run((helpers) => {
+      const { cold, expectObservable } = helpers
+      const getSecondProp = R.prop('secondProp')
+      const equalityFn = function (a) {
+        return getSecondProp(a) === getSecondProp(this)
+      }
+      const values = {
+        a: {
+          someKey: 'someValue1',
+          secondProp: 'thatIsSame',
+          equals: equalityFn
+        },
+        b: {
+          someKey: 'someValue2',
+          secondProp: 'thatIsSame',
+          equals: equalityFn
+        },
+        c: {
+          someKey: 'someValue3',
+          secondProp: 'thatIsSame',
+          equals: equalityFn
+        }
+      }
+      const e1 = cold(' -a--b--c---|', values)
+      const e1subs = '  ^----------!'
+      const expected = '-a---------'
+      expectObservable(e1.pipe(distinctUntilChanged), e1subs).toBe(expected, {
+        a: values.a
+      })
+    })
   })
 })


### PR DESCRIPTION
Motivation
I saw that there is an opportunity to write distinchUntilChanged in a way that will be as succintly as possible.
Because of this part of code in ramda equals:
https://github.com/ramda/ramda/blob/c207cf1be650e8373bef85a77198ba23647c9165/source/internal/_equals.js#L50
```js
export default function _equals(a, b, stackA, stackB) {
  /*... code ommited for brevity */
  if (typeof a.equals === 'function' || typeof b.equals === 'function') {
    return typeof a.equals === 'function' && a.equals(b) &&
      typeof b.equals === 'function' && b.equals(a);
  }
```

And also refactored existing tests and added a couple new using rxjs/testing's TestingSchedule