### PR TITLE
closes #35, closes #63; ability to prevent and restore app navigation

### DIFF
--- a/test/location.prevent-and-unblock-navigation.test.js
+++ b/test/location.prevent-and-unblock-navigation.test.js
@@ -1,0 +1,36 @@
+import {
+  createLocation$,
+  createNavigateTo$,
+  followLink$,
+  preventNavigation,
+} from '../src'
+
+test('Try to navigate with blocked navigation, then unblock navigation and try again', done => {
+  function whereverHandler() {
+    return createNavigateTo$('/wherever').subscribe()
+  }
+  
+  const location$ = createLocation$({
+    '/wherever': whereverHandler,
+  })
+
+  const locationSubscription = jest.fn()
+  let navigationCallback;
+  const getCurrentPathname = () => locationSubscription.mock.calls.at(-1)[0].get('pathname')
+  location$.subscribe(locationSubscription)
+
+  setTimeout(
+    () => {
+      expect(locationSubscription.mock.calls.length).toBe(1)
+      expect(getCurrentPathname()).toBe('/')
+      const unblockNavigation = preventNavigation(cb => navigationCallback = cb)
+      followLink$.next('/wherever')
+      expect(locationSubscription.mock.calls.length).toBe(1)
+      expect(getCurrentPathname()).toBe('/')
+      unblockNavigation()
+      followLink$.next('/wherever')
+      expect(locationSubscription.mock.calls.length).toBe(2)
+      expect(getCurrentPathname()).toBe('/wherever')
+      done()
+    }, 0)
+})

--- a/test/location.prevent-navigation-and-continue.test.js
+++ b/test/location.prevent-navigation-and-continue.test.js
@@ -1,0 +1,37 @@
+import {
+    createLocation$,
+    createNavigateTo$,
+    followLink$,
+    preventNavigation,
+} from '../src'
+
+test('Block navigation but decide to continue', done => {
+    function whereverHandler() {
+        return createNavigateTo$('/wherever').subscribe()
+    }
+
+    const location$ = createLocation$({
+        '/wherever': whereverHandler,
+    })
+
+    const locationSubscription = jest.fn()
+    let navigationCallback;
+    const getCurrentPathname = () => locationSubscription.mock.calls.at(-1)[0].get('pathname')
+    location$.subscribe(locationSubscription)
+
+    setTimeout(
+        () => {
+            expect(locationSubscription.mock.calls.length).toBe(1)
+            expect(getCurrentPathname()).toBe('/')
+            preventNavigation(cb => navigationCallback = cb)
+            followLink$.next('/wherever')
+            expect(locationSubscription.mock.calls.length).toBe(1)
+            expect(getCurrentPathname()).toBe('/')
+            setTimeout(() => {
+                navigationCallback(true)
+                expect(locationSubscription.mock.calls.length).toBe(2)
+                expect(getCurrentPathname()).toBe('/wherever')
+                done()
+            }, 0)
+        }, 0)
+})

--- a/test/location.prevent-navigation-and-stay.test.js
+++ b/test/location.prevent-navigation-and-stay.test.js
@@ -1,0 +1,37 @@
+import {
+    createLocation$,
+    createNavigateTo$,
+    followLink$,
+    preventNavigation,
+} from '../src'
+
+test('Block navigation and decide not to continue', done => {
+    function whereverHandler() {
+        return createNavigateTo$('/wherever').subscribe()
+    }
+
+    const location$ = createLocation$({
+        '/wherever': whereverHandler,
+    })
+
+    const locationSubscription = jest.fn()
+    let navigationCallback;
+    const getCurrentPathname = () => locationSubscription.mock.calls.at(-1)[0].get('pathname')
+    location$.subscribe(locationSubscription)
+
+    setTimeout(
+        () => {
+            expect(locationSubscription.mock.calls.length).toBe(1)
+            expect(getCurrentPathname()).toBe('/')
+            preventNavigation(cb => navigationCallback = cb)
+            followLink$.next('/wherever')
+            expect(locationSubscription.mock.calls.length).toBe(1)
+            expect(getCurrentPathname()).toBe('/')
+            setTimeout(() => {
+                navigationCallback(false)
+                expect(locationSubscription.mock.calls.length).toBe(1)
+                expect(getCurrentPathname()).toBe('/')
+                done()
+            }, 0)
+        }, 0)
+})


### PR DESCRIPTION
**Use case**: User is filling in a form and before saving the details, he's clicking a link to navigate to different page. I'd like to be able to show him a notification that unsaved changes will be lost, so that he can decide if he wants to stay on this page or navigate away.

**Problem**: `caballo-vivo` is already using `history.block()` to control managed paths, so using `history.block()` within consuming app is breaking navigation for managed paths.

**Solution**: `caballo-vivo` could export a method to block/unblock navigation

**Example** usage as react hook:

```
import React, {useEffect} from 'react'
import { preventNavigation } from '@zambezi/caballo-vivo'

...

  useEffect(() => {
    if (isFormDirty) {
      const unblockNavigation = preventNavigation(callback => {
        callback(window.confirm("There are unsaved changes, are you sure you want to leave?"))
      })

      return unblockNavigation 
    }
  }, [isFormDirty])

...

```